### PR TITLE
Allow users to set component names

### DIFF
--- a/src/policy-TerraformUpdateAccess.tf
+++ b/src/policy-TerraformUpdateAccess.tf
@@ -14,7 +14,7 @@ module "tfstate" {
 
   bypass = !local.tf_update_access_enabled
 
-  component   = "tfstate-backend"
+  component   = var.tfstate_backend_component_name
   environment = var.tfstate_environment_name
   stage       = module.iam_roles.global_stage_name
   privileged  = var.privileged

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -2,7 +2,7 @@ module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = "account-map"
+  component   = var.account_map_component_name
   environment = module.iam_roles.global_environment_name
   stage       = module.iam_roles.global_stage_name
   tenant      = module.iam_roles.global_tenant_name

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -64,3 +64,9 @@ variable "tfstate_backend_component_name" {
   description = "The name of the tfstate-backend component"
   default     = "tfstate-backend"
 }
+
+variable "account_map_component_name" {
+  type        = string
+  description = "The name of the account-map component"
+  default     = "account-map"
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -58,3 +58,9 @@ variable "session_duration" {
   description = "The default duration of the session in seconds for all permission sets. If not set, fallback to the default value in the module, which is 1 hour."
   default     = ""
 }
+
+variable "tfstate_backend_component_name" {
+  type        = string
+  description = "The name of the tfstate-backend component"
+  default     = "tfstate-backend"
+}


### PR DESCRIPTION
Allow users to set component names.

* Defined input variables `tfstate_backend_component_name` and `account_map_component_name`.
* Variables default to preserving the behaviour of the current version.
* This update allows the codebase to adopt more standardized structure and naming practices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable options to customize the names of the tfstate-backend and account-map components, enhancing flexibility in component naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->