### PR TITLE
fix: Skip DynamoDB in Terraform Policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ github/
 *.ovpn
 
 *.zip
+account-map/

--- a/src/policy-TerraformUpdateAccess.tf
+++ b/src/policy-TerraformUpdateAccess.tf
@@ -34,11 +34,16 @@ data "aws_iam_policy_document" "terraform_update_access" {
       "${module.tfstate.outputs.tfstate_backend_s3_bucket_arn}/*"
     ] : []
   }
-  statement {
-    sid       = "TerraformStateBackendDynamoDbTable"
-    effect    = "Allow"
-    actions   = ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:DeleteItem"]
-    resources = module.this.enabled ? [module.tfstate.outputs.tfstate_backend_dynamodb_table_arn] : []
+
+  dynamic "statement" {
+    for_each = (module.this.enabled && module.tfstate.outputs.tfstate_backend_dynamodb_table_arn != "") ? [1] : []
+
+    content {
+      sid       = "TerraformStateBackendDynamoDbTable"
+      effect    = "Allow"
+      actions   = ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:DeleteItem"]
+      resources = [module.tfstate.outputs.tfstate_backend_dynamodb_table_arn]
+    }
   }
 }
 


### PR DESCRIPTION
## what
- Skip the DynamoDB table permission in the TerraformUpdateAccess policy when the table does not exist

## why
- If we create the backend with `s3_state_lock_enabled: false`, then the DynamoDB table will not exist and this will be an invalid policy.

## references
- https://github.com/orgs/cloudposse/discussions/97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Added an ignore rule to prevent committing account map artifacts to the repository.

- Refactor
  - Made the infrastructure access policy conditional, applying it only when the feature is enabled and a valid backend resource is provided. This reduces unnecessary permissions and avoids misconfigurations without altering behavior when conditions are not met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->