### PR TITLE
Added variable overridable_team_permission_set_name_pattern to match the capability of aws-account-map

### DIFF
--- a/src/policy-Identity-role-TeamAccess.tf
+++ b/src/policy-Identity-role-TeamAccess.tf
@@ -41,8 +41,8 @@ data "aws_iam_policy_document" "assume_aws_team" {
 module "role_map" {
   source = "../account-map/modules/roles-to-principals"
 
-  teams      = var.aws_teams_accessible
-  privileged = var.privileged
+  teams                                        = var.aws_teams_accessible
+  privileged                                   = var.privileged
   overridable_team_permission_set_name_pattern = var.overridable_team_permission_set_name_pattern
 
   context = module.this.context

--- a/src/policy-Identity-role-TeamAccess.tf
+++ b/src/policy-Identity-role-TeamAccess.tf
@@ -43,6 +43,7 @@ module "role_map" {
 
   teams      = var.aws_teams_accessible
   privileged = var.privileged
+  overridable_team_permission_set_name_pattern = var.overridable_team_permission_set_name_pattern
 
   context = module.this.context
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -70,3 +70,10 @@ variable "account_map_component_name" {
   description = "The name of the account-map component"
   default     = "account-map"
 }
+
+variable "overridable_team_permission_set_name_pattern" {
+  type        = string
+  description = "The pattern used to generate the AWS SSO PermissionSet name for each team"
+  default     = "Identity%sTeamAccess"
+}
+


### PR DESCRIPTION
### Added

- A new variable, `overridable_team_permission_set_name_pattern`, has been introduced to align with the corresponding capability in `aws-account-map`.  
- When the default team permission set name pattern is overridden in `aws-account-map`, the same value must also be specified in this component.  
- By default, the variable preserves the existing behavior, using the pattern `"Identity%sTeamAccess"`.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable pattern for team AWS SSO Permission Set names so users can customize naming; default remains "Identity%sTeamAccess".
* **Chores**
  * Minor formatting cleanup in variable declarations (no functional impact).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->