### PR TITLE
fix: Session Duration

### DIFF
--- a/src/policy-BillingAdministratorAccess.tf
+++ b/src/policy-BillingAdministratorAccess.tf
@@ -3,7 +3,7 @@ locals {
     name             = "BillingAdministratorAccess",
     description      = "Grants permissions for billing and cost management. This includes viewing account usage and viewing and modifying budgets and payment methods.",
     relay_state      = "https://console.aws.amazon.com/billing/",
-    session_duration = "",
+    session_duration = var.session_duration,
     tags             = {},
     inline_policy    = ""
     policy_attachments = [

--- a/src/policy-BillingReadOnlyAccess.tf
+++ b/src/policy-BillingReadOnlyAccess.tf
@@ -3,7 +3,7 @@ locals {
     name             = "BillingReadOnlyAccess",
     description      = "Allow users to view bills in the billing console",
     relay_state      = "",
-    session_duration = "",
+    session_duration = var.session_duration,
     tags             = {},
     inline_policy    = ""
     policy_attachments = [

--- a/src/policy-DNSAdministratorAccess.tf
+++ b/src/policy-DNSAdministratorAccess.tf
@@ -30,7 +30,7 @@ locals {
     name                                = "DNSRecordAdministratorAccess",
     description                         = "Allow DNS Record Administrator access to the account, but not zone administration",
     relay_state                         = "https://console.aws.amazon.com/route53/",
-    session_duration                    = "",
+    session_duration                    = var.session_duration,
     tags                                = {},
     inline_policy                       = data.aws_iam_policy_document.dns_administrator_access.json,
     policy_attachments                  = ["arn:${local.aws_partition}:iam::aws:policy/AWSSupportAccess"]

--- a/src/policy-Identity-role-TeamAccess.tf
+++ b/src/policy-Identity-role-TeamAccess.tf
@@ -53,7 +53,7 @@ locals {
     name                                = module.role_map.team_permission_set_name_map[role],
     description                         = format("Allow user to assume the %s Team role in the Identity account, which allows access to other accounts", replace(title(role), "-", ""))
     relay_state                         = "",
-    session_duration                    = "",
+    session_duration                    = var.session_duration,
     tags                                = {},
     inline_policy                       = data.aws_iam_policy_document.assume_aws_team[role].json
     policy_attachments                  = ["arn:${local.aws_partition}:iam::aws:policy/job-function/ViewOnlyAccess"]

--- a/src/policy-ReadOnlyAccess.tf
+++ b/src/policy-ReadOnlyAccess.tf
@@ -3,7 +3,7 @@ locals {
     name             = "ReadOnlyAccess",
     description      = "Allow Read Only access to the account",
     relay_state      = "",
-    session_duration = "",
+    session_duration = var.session_duration,
     tags             = {},
     inline_policy    = data.aws_iam_policy_document.eks_read_only.json,
     policy_attachments = [


### PR DESCRIPTION
## what
- Session duration was missing from several permission sets in the `aws-sso` component

## why
- We set `var.session_duration` for all Permission Sets in the component, but several were missed

## references
- . 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session duration for access policies is now configurable through a variable, enabling administrators to control session timeouts consistently across Billing Administrator, Billing Read-Only, DNS Administrator, Team Access, and Read-Only access policies instead of using static placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->