### PR TITLE
Add toggle for provisioning default permission sets

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -79,14 +79,16 @@ module "permission_sets" {
 
   permission_sets = concat(
     local.overridable_additional_permission_sets,
-    local.administrator_access_permission_set,
-    local.billing_administrator_access_permission_set,
-    local.billing_read_only_access_permission_set,
-    local.dns_administrator_access_permission_set,
     local.identity_access_permission_sets,
-    local.poweruser_access_permission_set,
-    local.read_only_access_permission_set,
     local.terraform_update_access_permission_set,
+    var.provision_sensible_permission_sets ? concat(
+      local.administrator_access_permission_set,
+      local.billing_administrator_access_permission_set,
+      local.billing_read_only_access_permission_set,
+      local.dns_administrator_access_permission_set,
+      local.poweruser_access_permission_set,
+      local.read_only_access_permission_set
+    ) : []
   )
 
   context = module.this.context

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -77,3 +77,8 @@ variable "overridable_team_permission_set_name_pattern" {
   default     = "Identity%sTeamAccess"
 }
 
+variable "provision_sensible_permission_sets" {
+  type        = bool
+  description = "Provision sensible defaults for the AWS SSO PermissionSet"
+  default     = true
+}


### PR DESCRIPTION
### Summary
This PR introduces a new option that lets users control whether the default permission sets are automatically provisioned. The change is primarily cosmetic, intended to accommodate different naming conventions for these standard permission sets, rather than to alter core functionality.

### Details
* A new variable, `provision_sensible_permission_sets`, has been added.
Default: `true` - preserves the existing behavior.
* When set to `false`, the following permission sets **will not** be provisioned:
  * `AdministratorAccess`
  * `BillingAdministratorAccess`
  * `BillingReadOnlyAccess`
  * `DNSRecordAdministratorAccess`
  * `PowerUserAccess`
  * `ReadOnlyAccess`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to control provisioning of default AWS SSO permission sets. Enabled by default to maintain backward compatibility while allowing users to customize permission set configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->