### PR TITLE
feat: pass tags to permission sets

### DIFF
--- a/src/policy-AdminstratorAccess.tf
+++ b/src/policy-AdminstratorAccess.tf
@@ -4,7 +4,7 @@ locals {
     description                         = "Allow Full Administrator access to the account",
     relay_state                         = "",
     session_duration                    = var.session_duration,
-    tags                                = {},
+    tags                                = module.this.tags,
     inline_policy                       = ""
     policy_attachments                  = ["arn:${local.aws_partition}:iam::aws:policy/AdministratorAccess"]
     customer_managed_policy_attachments = []

--- a/src/policy-BillingAdministratorAccess.tf
+++ b/src/policy-BillingAdministratorAccess.tf
@@ -4,7 +4,7 @@ locals {
     description      = "Grants permissions for billing and cost management. This includes viewing account usage and viewing and modifying budgets and payment methods.",
     relay_state      = "https://console.aws.amazon.com/billing/",
     session_duration = var.session_duration,
-    tags             = {},
+    tags             = module.this.tags,
     inline_policy    = ""
     policy_attachments = [
       "arn:${local.aws_partition}:iam::aws:policy/job-function/Billing",

--- a/src/policy-BillingReadOnlyAccess.tf
+++ b/src/policy-BillingReadOnlyAccess.tf
@@ -4,7 +4,7 @@ locals {
     description      = "Allow users to view bills in the billing console",
     relay_state      = "",
     session_duration = var.session_duration,
-    tags             = {},
+    tags             = module.this.tags,
     inline_policy    = ""
     policy_attachments = [
       "arn:${local.aws_partition}:iam::aws:policy/AWSBillingReadOnlyAccess",

--- a/src/policy-DNSAdministratorAccess.tf
+++ b/src/policy-DNSAdministratorAccess.tf
@@ -31,7 +31,7 @@ locals {
     description                         = "Allow DNS Record Administrator access to the account, but not zone administration",
     relay_state                         = "https://console.aws.amazon.com/route53/",
     session_duration                    = var.session_duration,
-    tags                                = {},
+    tags                                = module.this.tags,
     inline_policy                       = data.aws_iam_policy_document.dns_administrator_access.json,
     policy_attachments                  = ["arn:${local.aws_partition}:iam::aws:policy/AWSSupportAccess"]
     customer_managed_policy_attachments = []

--- a/src/policy-Identity-role-TeamAccess.tf
+++ b/src/policy-Identity-role-TeamAccess.tf
@@ -54,7 +54,7 @@ locals {
     description                         = format("Allow user to assume the %s Team role in the Identity account, which allows access to other accounts", replace(title(role), "-", ""))
     relay_state                         = "",
     session_duration                    = var.session_duration,
-    tags                                = {},
+    tags                                = module.this.tags,
     inline_policy                       = data.aws_iam_policy_document.assume_aws_team[role].json
     policy_attachments                  = ["arn:${local.aws_partition}:iam::aws:policy/job-function/ViewOnlyAccess"]
     customer_managed_policy_attachments = []

--- a/src/policy-PoweruserAccess.tf
+++ b/src/policy-PoweruserAccess.tf
@@ -4,7 +4,7 @@ locals {
     description      = "Allow Poweruser access to the account",
     relay_state      = "",
     session_duration = var.session_duration,
-    tags             = {},
+    tags             = module.this.tags,
     inline_policy    = ""
     policy_attachments = [
       "arn:${local.aws_partition}:iam::aws:policy/PowerUserAccess",

--- a/src/policy-ReadOnlyAccess.tf
+++ b/src/policy-ReadOnlyAccess.tf
@@ -4,7 +4,7 @@ locals {
     description      = "Allow Read Only access to the account",
     relay_state      = "",
     session_duration = var.session_duration,
-    tags             = {},
+    tags             = module.this.tags,
     inline_policy    = data.aws_iam_policy_document.eks_read_only.json,
     policy_attachments = [
       "arn:${local.aws_partition}:iam::aws:policy/ReadOnlyAccess",

--- a/src/policy-TerraformUpdateAccess.tf
+++ b/src/policy-TerraformUpdateAccess.tf
@@ -53,7 +53,7 @@ locals {
     description                         = "Allow access to Terraform state sufficient to make changes",
     relay_state                         = "",
     session_duration                    = var.session_duration,
-    tags                                = {},
+    tags                                = module.this.tags,
     inline_policy                       = one(data.aws_iam_policy_document.terraform_update_access[*].json),
     policy_attachments                  = []
     customer_managed_policy_attachments = []


### PR DESCRIPTION
## what
* Added `module.this.tags` to permission sets

## why
* We were passing in nothing so this will help provide tags in AWS based on the component, etc

## references


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated IAM permission set configurations to inherit tags from module settings, enabling consistent metadata management across AdministratorAccess, BillingAdministratorAccess, BillingReadOnlyAccess, DNSAdministratorAccess, TeamAccess, PoweruserAccess, ReadOnlyAccess, and TerraformUpdateAccess permission sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->