### PR TITLE
Add `TerraformStateAccess` Permission Set

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -106,6 +106,7 @@ module "permission_sets" {
     local.terraform_plan_access_permission_set,
     local.terraform_apply_access_permission_set,
     local.terraform_update_access_permission_set,
+    local.terraform_state_access_permission_set,
   )
 
   context = module.this.context


### PR DESCRIPTION
This pull request introduces a new permission set specifically for managing Terraform state access. The main focus is to allow fine-grained, read/write access to the Terraform state backend (S3 and optionally DynamoDB), without granting broader account permissions. The most important changes are:

### New Terraform State Access Permission Set

* Added a new `terraform_state_access_permission_set` to the `locals` block, which is conditionally created when Terraform access is enabled. This permission set provides access only to the Terraform state backend resources.
* Defined a new `aws_iam_policy_document` data source, `terraform_state_access`, which grants S3 read/write permissions for the state bucket, optional DynamoDB table permissions for state locking, and the ability to assume the backend role.
* Included the new `terraform_state_access_permission_set` in the list of permission sets passed to the `permission_sets` module, ensuring it is provisioned alongside the other Terraform-related permission sets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Terraform state access permission set enabling read/write access to Terraform state backends, including S3 bucket operations and DynamoDB table access. The feature is configurable and allows assuming a designated role for state access operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->