### PR TITLE
Add Partner Central Permission Sets mixin

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -145,6 +145,126 @@ usage: |-
   7. If you want the permission set to be able to use Terraform, enable access to the Terraform state read/write (default)
     role in `tfstate-backend`.
 
+  ### Using Mixins
+
+  Mixins provide a way to extend the component with additional permission sets without modifying the core component code.
+  This makes it easier to keep your components up-to-date with upstream changes while maintaining custom functionality.
+
+  #### Available Mixins
+
+  This component provides several mixins in the [`mixins/`](./mixins) directory:
+
+  - **`policy-PartnerCentral.tf`** - AWS Partner Central permission sets for AWS Partner Network (APN) integration
+
+  See the [mixins/README.md](./mixins/README.md) for a complete list of available mixins and detailed documentation.
+
+  #### Vendoring Mixins
+
+  **Option 1: Via component.yaml (Recommended)**
+
+  Add the mixin to your component's `component.yaml` file:
+
+  ```yaml
+  # components/terraform/aws-sso/component.yaml
+  apiVersion: atmos/v1
+  kind: ComponentVendorConfig
+  spec:
+    source:
+      uri: github.com/cloudposse-terraform-components/aws-identity-center.git//src?ref={{ .Version }}
+      version: 1.0.0
+      included_paths:
+        - "**/**"
+      excluded_paths: []
+
+    # Mixins are pulled and merged into your component directory
+    mixins:
+      - uri: github.com/cloudposse-terraform-components/aws-identity-center.git//mixins/policy-PartnerCentral.tf?ref={{ .Version }}
+        version: 1.0.0
+        filename: policy-PartnerCentral.tf
+  ```
+
+  **Option 2: Via vendor.yaml**
+
+  Use a centralized `vendor.yaml` file:
+
+  ```yaml
+  # vendor.yaml
+  apiVersion: atmos/v1
+  kind: AtmosVendorConfig
+  spec:
+    sources:
+      - component: "terraform/aws-sso"
+        source: "github.com/cloudposse-terraform-components/aws-identity-center.git//src?ref={{ .Version }}"
+        version: "1.0.0"
+        targets:
+          - "components/terraform/aws-sso"
+        mixins:
+          - source: "github.com/cloudposse-terraform-components/aws-identity-center.git//mixins/policy-PartnerCentral.tf?ref={{ .Version }}"
+            version: "1.0.0"
+            filename: "policy-PartnerCentral.tf"
+  ```
+
+  Then run:
+  ```bash
+  atmos vendor pull -c aws-sso
+  ```
+
+  #### Activating Vendored Permission Sets
+
+  After vendoring a mixin, include the permission sets in your component by updating `additional-permission-sets_override.tf`:
+
+  ```hcl
+  # components/terraform/aws-sso/additional-permission-sets_override.tf
+  locals {
+    # Add custom permission sets.
+    # Mixins define local variables (e.g., local.partner_central_permission_sets)
+    # that you concatenate into this list.
+    overridable_additional_permission_sets = concat(
+      local.partner_central_permission_sets,  # From policy-PartnerCentral.tf mixin
+      # Add other permission set locals here as needed
+      # local.custom_permission_sets,
+    )
+  }
+  ```
+
+  Each mixin defines a local variable containing its permission sets. For example, `policy-PartnerCentral.tf` defines
+  `local.partner_central_permission_sets` with 8 permission sets for AWS Partner Central.
+
+  #### Creating Custom Mixins
+
+  You can create your own mixin files following this pattern:
+
+  ```hcl
+  # components/terraform/aws-sso/policy-CustomRole.tf
+  locals {
+    custom_permission_sets = [
+      {
+        name                                = "MyCustomRole"
+        description                         = "Description of the role"
+        relay_state                         = ""
+        session_duration                    = ""
+        tags                                = {}
+        inline_policy                       = ""
+        policy_attachments                  = ["arn:${local.aws_partition}:iam::aws:policy/CustomPolicy"]
+        customer_managed_policy_attachments = []
+      },
+    ]
+  }
+  ```
+
+  Then reference it in `additional-permission-sets_override.tf`:
+
+  ```hcl
+  locals {
+    overridable_additional_permission_sets = concat(
+      local.custom_permission_sets,
+      local.partner_central_permission_sets,
+    )
+  }
+  ```
+
+  For more details, see [mixins/README.md](./mixins/README.md).
+
   #### Example
 
   The example snippet below shows how to use this module with various combinations (plain YAML, YAML Anchors and a

--- a/mixins/README.md
+++ b/mixins/README.md
@@ -1,0 +1,154 @@
+# AWS Identity Center Mixins
+
+This directory contains mixin files that can be vendored into your `aws-identity-center` (formerly `aws-sso`) component to add additional permission sets.
+
+## What are Mixins?
+
+Mixins are additional Terraform files that extend the base component functionality. They allow you to add custom permission sets without modifying the core component code, making it easier to:
+- Keep your components up-to-date with upstream changes
+- Share common permission set definitions across teams
+- Maintain separation between core and custom functionality
+
+## Available Mixins
+
+### `policy-PartnerCentral.tf`
+
+Provides 8 AWS Partner Central permission sets for AWS Partner Network (APN) integration:
+
+- `PartnerCentralFullAccess` - Full access to AWS Partner Central and related services
+- `PartnerCentralAccountMgmt` - Manage IAM roles linked to partner users
+- `PartnerCentralOpportunityMgmt` - Manage opportunities in AWS Partner Central
+- `PartnerCentralSandboxAccess` - Developer testing in the Sandbox catalog
+- `PartnerCentralResourceSnapshot` - ResourceSnapshotJob permissions
+- `PartnerCentralChannelMgmt` - Manage channel programs and relationships
+- `PartnerCentralHandshakeMgmt` - Channel handshake approval management
+- `PartnerCentralMarketingMgmt` - Manage marketing activities and campaigns
+
+## Usage
+
+### Option 1: Vendor Mixin via component.yaml
+
+Add the mixin to your component's `component.yaml` file:
+
+```yaml
+# components/terraform/aws-sso/component.yaml
+apiVersion: atmos/v1
+kind: ComponentVendorConfig
+spec:
+  source:
+    uri: github.com/cloudposse-terraform-components/aws-identity-center.git//src?ref={{ .Version }}
+    version: 1.0.0
+    included_paths:
+      - "**/**"
+    excluded_paths: []
+
+  # Mixins are pulled and merged into your component directory
+  mixins:
+    - uri: github.com/cloudposse-terraform-components/aws-identity-center.git//mixins/policy-PartnerCentral.tf?ref={{ .Version }}
+      version: 1.0.0
+      filename: policy-PartnerCentral.tf
+```
+
+Then run:
+```bash
+atmos vendor pull -c aws-sso
+```
+
+### Option 2: Vendor Mixin via vendor.yaml
+
+Alternatively, use a centralized `vendor.yaml` file:
+
+```yaml
+# vendor.yaml
+apiVersion: atmos/v1
+kind: AtmosVendorConfig
+spec:
+  imports: []
+  sources:
+    - component: "terraform/aws-sso"
+      source: "github.com/cloudposse-terraform-components/aws-identity-center.git//src?ref={{ .Version }}"
+      version: "1.0.0"
+      targets:
+        - "components/terraform/aws-sso"
+      included_paths:
+        - "**/**"
+      excluded_paths: []
+      mixins:
+        - source: "github.com/cloudposse-terraform-components/aws-identity-center.git//mixins/policy-PartnerCentral.tf?ref={{ .Version }}"
+          version: "1.0.0"
+          filename: "policy-PartnerCentral.tf"
+```
+
+Then run:
+```bash
+atmos vendor pull
+```
+
+### Option 3: Manual Copy
+
+Simply copy the mixin file directly to your component directory:
+
+```bash
+cp mixins/policy-PartnerCentral.tf components/terraform/aws-sso/
+```
+
+## Activating Vendored Permission Sets
+
+After vendoring the mixin, you need to include the permission sets in your component. Create or update the `additional-permission-sets_override.tf` file:
+
+```hcl
+# components/terraform/aws-sso/additional-permission-sets_override.tf
+locals {
+  # Add custom permission sets.
+  # See the README for more details.
+  overridable_additional_permission_sets = concat(
+    local.partner_central_permission_sets,  # Add this line
+    # Add other permission set locals here as needed
+    # local.custom_permission_sets,
+    # local.security_permission_sets,
+  )
+}
+```
+
+The mixin defines `local.partner_central_permission_sets`, which you concatenate into `local.overridable_additional_permission_sets`. This local variable is merged with the component's base permission sets.
+
+## Pattern for Creating Your Own Mixins
+
+To create additional mixin files:
+
+1. Create a `.tf` file in the mixins directory
+2. Define a local variable with your permission sets:
+
+```hcl
+locals {
+  my_custom_permission_sets = [
+    {
+      name                                = "MyCustomRole"
+      description                         = "Description of the role"
+      relay_state                         = ""
+      session_duration                    = ""
+      tags                                = {}
+      inline_policy                       = ""
+      policy_attachments                  = ["arn:${local.aws_partition}:iam::aws:policy/CustomPolicy"]
+      customer_managed_policy_attachments = []
+    },
+  ]
+}
+```
+
+3. Reference it in `additional-permission-sets_override.tf`:
+
+```hcl
+locals {
+  overridable_additional_permission_sets = concat(
+    local.my_custom_permission_sets,
+    local.partner_central_permission_sets,
+  )
+}
+```
+
+## References
+
+- [Atmos Vendor Documentation](https://atmos.tools/core-concepts/vendoring)
+- [AWS Identity Center Component](https://github.com/cloudposse-terraform-components/aws-identity-center)
+- [AWS Partner Central Documentation](https://docs.aws.amazon.com/partner-central/)

--- a/mixins/policy-PartnerCentral.tf
+++ b/mixins/policy-PartnerCentral.tf
@@ -1,0 +1,84 @@
+locals {
+  partner_central_permission_sets = [
+    {
+      name                                = "PartnerCentralFullAccess"
+      description                         = "This policy grants full access to AWS Partner Central and related AWS services."
+      relay_state                         = ""
+      session_duration                    = ""
+      tags                                = {}
+      inline_policy                       = ""
+      policy_attachments                  = ["arn:${local.aws_partition}:iam::aws:policy/AWSPartnerCentralFullAccess"]
+      customer_managed_policy_attachments = []
+    },
+    {
+      name                                = "PartnerCentralAccountMgmt"
+      description                         = "This policy is used by a partner cloud admin to manage IAM roles linked to partner users."
+      relay_state                         = ""
+      session_duration                    = ""
+      tags                                = {}
+      inline_policy                       = ""
+      policy_attachments                  = ["arn:${local.aws_partition}:iam::aws:policy/PartnerCentralAccountManagementUserRoleAssociation"]
+      customer_managed_policy_attachments = []
+    },
+    {
+      name                                = "PartnerCentralOpportunityMgmt"
+      description                         = "This policy grants full access to manage opportunities in AWS Partner Central."
+      relay_state                         = ""
+      session_duration                    = ""
+      tags                                = {}
+      inline_policy                       = ""
+      policy_attachments                  = ["arn:${local.aws_partition}:iam::aws:policy/AWSPartnerCentralOpportunityManagement"]
+      customer_managed_policy_attachments = []
+    },
+    {
+      name                                = "PartnerCentralSandboxAccess"
+      description                         = "This policy grants access for developer testing in the Sandbox catalog."
+      relay_state                         = ""
+      session_duration                    = ""
+      tags                                = {}
+      inline_policy                       = ""
+      policy_attachments                  = ["arn:${local.aws_partition}:iam::aws:policy/AWSPartnerCentralSandboxFullAccess"]
+      customer_managed_policy_attachments = []
+    },
+    {
+      name                                = "PartnerCentralResourceSnapshot"
+      description                         = "This policy provides the ResourceSnapshotJob with permission to read a resource and snapshot it in the target environment."
+      relay_state                         = ""
+      session_duration                    = ""
+      tags                                = {}
+      inline_policy                       = ""
+      policy_attachments                  = ["arn:${local.aws_partition}:iam::aws:policy/AWSPartnerCentralSellingResourceSnapshotJobExecutionRolePolicy"]
+      customer_managed_policy_attachments = []
+    },
+    {
+      name                                = "PartnerCentralChannelMgmt"
+      description                         = "This policy grants access to manage channel programs and relationships in AWS Partner Central."
+      relay_state                         = ""
+      session_duration                    = ""
+      tags                                = {}
+      inline_policy                       = ""
+      policy_attachments                  = ["arn:${local.aws_partition}:iam::aws:policy/AWSPartnerCentralChannelManagement"]
+      customer_managed_policy_attachments = []
+    },
+    {
+      name                                = "PartnerCentralHandshakeMgmt"
+      description                         = "This policy grants access to channel handshake approval management activities in AWS Partner Central."
+      relay_state                         = ""
+      session_duration                    = ""
+      tags                                = {}
+      inline_policy                       = ""
+      policy_attachments                  = ["arn:${local.aws_partition}:iam::aws:policy/AWSPartnerCentralChannelHandshakeApprovalManagement"]
+      customer_managed_policy_attachments = []
+    },
+    {
+      name                                = "PartnerCentralMarketingMgmt"
+      description                         = "This policy grants access to manage marketing activities and campaigns in AWS Partner Central."
+      relay_state                         = ""
+      session_duration                    = ""
+      tags                                = {}
+      inline_policy                       = ""
+      policy_attachments                  = ["arn:${local.aws_partition}:iam::aws:policy/AWSPartnerCentralMarketingManagement"]
+      customer_managed_policy_attachments = []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds a new mixin file `policy-PartnerCentral.tf` with 8 AWS Partner Central permission sets
- Enables AWS Partner Central integration and AWS Partner Network (APN) program management

## Permission Sets Included
1. **PartnerCentralFullAccess** - Full access to AWS Partner Central and related services
2. **PartnerCentralAccountMgmt** - Manage IAM roles linked to partner users
3. **PartnerCentralOpportunityMgmt** - Manage opportunities in AWS Partner Central
4. **PartnerCentralSandboxAccess** - Developer testing in the Sandbox catalog
5. **PartnerCentralResourceSnapshot** - ResourceSnapshotJob permissions
6. **PartnerCentralChannelMgmt** - Manage channel programs and relationships
7. **PartnerCentralHandshakeMgmt** - Channel handshake approval management
8. **PartnerCentralMarketingMgmt** - Manage marketing activities and campaigns

## Test plan
- [ ] Verify mixin file can be imported into aws-identity-center component
- [ ] Validate Terraform syntax and formatting
- [ ] Confirm permission sets are available in catalog configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added structured Partner Central permission-set configurations covering nine Partner Central role types for consistent, reusable access definitions.

* **Documentation**
  * Added comprehensive mixins documentation and "Using Mixins" guidance with vendoring workflows, activation steps, examples, and instructions for creating and integrating custom permission-set mixins.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->