### PR TITLE
feat: expose ssoadmin_instance_arn and identity_store_id outputs

### DIFF
--- a/mixins/policy-TerraformUpdateAccess.tf
+++ b/mixins/policy-TerraformUpdateAccess.tf
@@ -4,7 +4,7 @@ locals {
 
 module "tfstate" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   bypass = !local.tf_update_access_enabled
 

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -1,3 +1,13 @@
+output "ssoadmin_instance_arn" {
+  value       = one(data.aws_ssoadmin_instances.this.arns)
+  description = "ARN of the AWS IAM Identity Center (SSO) instance"
+}
+
+output "identity_store_id" {
+  value       = one(data.aws_ssoadmin_instances.this.identity_store_ids)
+  description = "ID of the Identity Store associated with the SSO instance"
+}
+
 output "permission_sets" {
   value       = module.permission_sets.permission_sets
   description = "Permission sets"


### PR DESCRIPTION
## Summary
- Add `ssoadmin_instance_arn` output -- ARN of the AWS IAM Identity Center instance
- Add `identity_store_id` output -- ID of the associated Identity Store

Both values come from the existing `data.aws_ssoadmin_instances.this` data source in `main.tf` -- no new resources or data sources needed.

These outputs enable cross-component references via `!terraform.state`, e.g. for configuring EKS Argo CD capabilities which require the IDC instance ARN:

```yaml
capabilities:
  argocd:
    configuration:
      argo_cd:
        aws_idc:
          idc_instance_arn: !terraform.state aws-sso core-gbl-root ssoadmin_instance_arn
```

## Test plan
- [ ] `terraform validate` passes
- [ ] `terraform plan` on existing deployment shows only new outputs (no resource changes)
- [ ] Verify `ssoadmin_instance_arn` output matches expected ARN format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two new outputs exposed: AWS Single Sign-On Admin instance ARN and identity store ID, making SSO configuration values available for dependent resources.

* **Chores**
  * Updated remote-state module to a newer major version to align with platform updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->