### PR TITLE
feat: add group_map and user_map outputs

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -36,6 +36,12 @@ locals {
 
   account_assignments = concat(local.account_assignments_groups, local.account_assignments_users)
 
+  all_user_names = distinct(flatten([
+    for account_key, account in var.account_assignments : [
+      for user_key, user in lookup(account, "users", {}) : user_key
+    ]
+  ]))
+
   aws_partition = data.aws_partition.current.partition
 }
 
@@ -50,6 +56,19 @@ resource "aws_identitystore_group" "manual" {
   description  = "Group created with Terraform"
 
   identity_store_id = tolist(data.aws_ssoadmin_instances.this.identity_store_ids)[0]
+}
+
+data "aws_identitystore_user" "this" {
+  for_each = toset(local.all_user_names)
+
+  identity_store_id = tolist(data.aws_ssoadmin_instances.this.identity_store_ids)[0]
+
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "UserName"
+      attribute_value = each.key
+    }
+  }
 }
 
 # Look up IdP-managed groups (synced from Google Workspace, Okta, etc.)

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -25,3 +25,16 @@ output "group_ids" {
   )
   description = "Group IDs for Identity Center (includes both manually created and IdP-synced groups)"
 }
+
+output "group_map" {
+  value = merge(
+    { for group_key, group_output in aws_identitystore_group.manual : group_output.display_name => group_output.group_id },
+    { for group_key, group_output in data.aws_identitystore_group.idp : group_output.display_name => group_output.group_id }
+  )
+  description = "Map of group display name to group ID"
+}
+
+output "user_map" {
+  value = { for user_key, user_output in data.aws_identitystore_user.this : user_key => user_output.user_id }
+  description = "Map of user name to user ID"
+}

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -35,6 +35,6 @@ output "group_map" {
 }
 
 output "user_map" {
-  value = { for user_key, user_output in data.aws_identitystore_user.this : user_key => user_output.user_id }
+  value       = { for user_key, user_output in data.aws_identitystore_user.this : user_key => user_output.user_id }
   description = "Map of user name to user ID"
 }


### PR DESCRIPTION
## Summary

- Adds `group_map` output: maps group display name to group ID (both manual and IdP-synced groups)
- Adds `user_map` output: maps user name to user ID, automatically derived from users referenced in `account_assignments`
- Adds `aws_identitystore_user` data source to look up user IDs by username

These outputs make it easier for downstream consumers to look up group and user IDs by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic lookup of users in the identity store with de-duplication across account configurations.
  * Consolidated group map combining manual and synced groups with their IDs for simpler referencing.
  * New user map that exposes resolved user IDs keyed by user identifier for easier configuration use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->