### PR TITLE
fix: remove false depends_on causing cascading destroy/recreate

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -107,10 +107,6 @@ module "permission_sets" {
   )
 
   context = module.this.context
-
-  depends_on = [
-    aws_identitystore_group.manual
-  ]
 }
 
 module "sso_account_assignments" {
@@ -119,8 +115,4 @@ module "sso_account_assignments" {
 
   account_assignments = local.account_assignments
   context             = module.this.context
-
-  depends_on = [
-    aws_identitystore_group.manual
-  ]
 }


### PR DESCRIPTION
This was discovered by me , tested manually and the PR was generated with AI and tested by me again.
A human was involved.

## What

Remove `depends_on = [aws_identitystore_group.manual]` from both `permission_sets` and `sso_account_assignments` module calls in `src/main.tf`.

## Why

Adding any new group to `var.groups` triggers a catastrophic cascading destroy/recreate of **all** permission sets and account assignments (~41 resources in a typical deployment).

### Root Cause

When `depends_on` targets a resource collection (`aws_identitystore_group.manual`) that has **any** pending change — even adding a single new key to `for_each` — Terraform defers **all** data sources inside the dependent module to apply time.

This causes:

1. **`permission_sets` module:** `data.aws_ssoadmin_instances.this` is deferred → `local.sso_instance_arn` becomes `(known after apply)` → `instance_arn` on `aws_ssoadmin_permission_set` becomes unknown → **ForceNew** on every permission set → destroy+recreate of all permission sets + all policy attachments.

2. **`sso_account_assignments` module:** Same mechanism → `principal_id` becomes `(known after apply)` → force replacement of every account assignment.

### Why These Are False Dependencies

- **`permission_sets`** creates SSO permission sets (IAM policy bundles). These have **zero relationship** to Identity Store groups — they don't reference groups at all.
- **`sso_account_assignments`** does its own internal `data.aws_identitystore_group` lookup to resolve group names to IDs. It doesn't consume the `aws_identitystore_group.manual` resource outputs.

Terraform's implicit dependency graph handles the actual resource ordering correctly without explicit `depends_on`.

## Testing

Tested on a production-scale deployment (15 permission sets, 20+ policy attachments, 35+ account assignments, 7 IdP groups):

**Before (with `depends_on`):**
```
Plan: 41 to add, 0 to change, 41 to destroy.
```

**After (without `depends_on`):**
```
Plan: 1 to add, 0 to change, 0 to destroy.
```

The single addition is the new group — exactly what's expected.

## Migration

This is a **safe, backward-compatible change**. Removing `depends_on` does not alter any resource state. Existing deployments will see no plan diff after upgrading (assuming `var.groups` hasn't changed).

Users who previously worked around this bug by creating groups as standalone resources (outside `var.groups`) can now safely use `var.groups` as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved infrastructure deployment efficiency by removing restrictive dependency sequencing constraints between resources. This optimization enables more flexible resource provisioning across infrastructure components, reduces unnecessary forced timing requirements, and significantly enhances overall deployment performance and responsiveness. The change maintains complete system stability while supporting more efficient infrastructure provisioning workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->