### PR TITLE
feat: pass merged group_ids map to sso_account_assignments module

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -36,6 +36,18 @@ locals {
 
   account_assignments = concat(local.account_assignments_groups, local.account_assignments_users)
 
+  # Merged display_name → group_id map for the sso_account_assignments submodule.
+  # Resolving IDs here (instead of inside the submodule's data source) means
+  # plan succeeds even when a Terraform-managed group has not yet been
+  # created. Manual groups contribute group_id from aws_identitystore_group.manual
+  # (known-after-apply on first plan, stable thereafter); IdP groups contribute
+  # IDs from the data source (always succeeds for SCIM-synced groups).
+  # Requires terraform-aws-sso >= <next release with var.group_ids>.
+  all_group_ids = merge(
+    { for k, v in aws_identitystore_group.manual : k => v.group_id },
+    { for k, v in data.aws_identitystore_group.idp : k => v.group_id },
+  )
+
   all_user_names = distinct(flatten([
     for account_key, account in var.account_assignments : [
       for user_key, user in lookup(account, "users", {}) : user_key
@@ -114,5 +126,6 @@ module "sso_account_assignments" {
   version = "1.2.0"
 
   account_assignments = local.account_assignments
+  group_ids           = local.all_group_ids
   context             = module.this.context
 }


### PR DESCRIPTION
This is a continuation of the changes on identity center component. This code is running on my environment with IdP groups and local groups mixed.
Tested by a human

## what

Compute `local.all_group_ids` as a merge of:

- `aws_identitystore_group.manual` (Terraform-managed groups created by this component)
- `data.aws_identitystore_group.idp` (SCIM-synced groups)

Pass this map to `module.sso_account_assignments` via the new
`group_ids` input. The submodule resolves GROUP principals from this
map directly and skips its own `data.aws_identitystore_group.this`
lookup for any display name present in the map.

```diff
 module \"sso_account_assignments\" {
   source  = \"cloudposse/sso/aws//modules/account-assignments\"
   version = \"1.2.0\"

   account_assignments = local.account_assignments
+  group_ids           = local.all_group_ids
   context             = module.this.context
 }
```

## why

The submodule's data source fails at plan time with
`ResourceNotFoundException: GROUP not found` whenever an
`account_assignments` entry references a Terraform-managed group that has
not yet been created. This blocks the natural workflow of declaring a
group in `var.groups` **and** referencing it in `account_assignments` in
the same apply.

The previous mitigation — module-level `depends_on` on
`aws_identitystore_group.manual` — was removed in
[#74](https://github.com/cloudposse-terraform-components/aws-identity-center/pull/74)
because it caused cascading destroy/recreate of every permission set and
every existing account assignment whenever any group was added or
changed.

By pre-resolving the IDs in the parent module, the submodule no longer
needs to look up TF-managed groups at plan time. A single
`terraform apply` creates the group, the user, the membership, and the
assignment — no two-phase apply, no `-target`, no destroys.

## requires

This PR depends on the corresponding upstream change:

- [cloudposse/terraform-aws-sso#77](https://github.com/cloudposse/terraform-aws-sso/pull/77) — adds `var.group_ids` to the `account-assignments` submodule

After that PR is merged and tagged, the version pin
`version = \"1.2.0\"` should be bumped to the new release. Until then,
this PR will fail validation against the unmodified submodule (unknown
input variable). Hold for upstream merge before merging here.

## test plan

Validated end-to-end against a 9-account CloudTrail-managed AWS Org with
mixed Terraform-managed and SCIM-synced groups:

| Scenario | Result |
|---|---|
| Without fix, TF-managed group in `account_assignments` | `Error: ResourceNotFoundException: GROUP not found` |
| With fix, parent passes merged `group_ids` map | `Plan: 12 to add, 0 to change, 0 to destroy` |
| Existing ~20 SCIM-group assignments | `0 to change` — no spurious diffs |
| Existing ~15 permission sets | `0 to change` — no cascade |

- [x] `terraform fmt`
- [x] Plan against real stack succeeds
- [ ] CI checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated group ID management for SSO account assignments to handle both locally-managed and identity provider-managed groups through a unified mapping, improving plan-time consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->