### PR TITLE
Migrate Renovate config preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "prConcurrentLimit": 5,
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }


### PR DESCRIPTION
## what
- Migrate Renovate preset from `config:base` to `config:recommended`.

## why
- Renovate's Dependency Dashboard flags this repository with "Config Migration Needed".
- `config:recommended` is the current replacement for the deprecated `config:base` preset.

## testing
- Parsed `.github/renovate.json` as JSON.
- Ran `git diff --check`.
- Did not run Atmos/Terratest because this repository's AGENTS.md notes tests deploy real AWS resources and may incur costs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to use an improved preset for better handling of automated dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->