### PR TITLE
Upgrade account_map module version to 2.0.0

### DIFF
--- a/mixins/helpers.tf
+++ b/mixins/helpers.tf
@@ -1,0 +1,3 @@
+locals {
+  enabled = false
+}

--- a/src/main.tf
+++ b/src/main.tf
@@ -123,7 +123,7 @@ module "permission_sets" {
 
 module "sso_account_assignments" {
   source  = "cloudposse/sso/aws//modules/account-assignments"
-  version = "1.2.0"
+  version = "1.2.1"
 
   account_assignments = local.account_assignments
   group_ids           = local.all_group_ids

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -10,7 +10,7 @@
 #   - Allows the component to function without the account-map dependency
 module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component   = var.account_map_component_name
   tenant      = var.account_map_enabled ? module.iam_roles.global_tenant_name : null


### PR DESCRIPTION
## what
* Upgrade account_map module version to 2.0.0

## why
* Fix cloudposse/utils provider version constraints

## references
* https://github.com/cloudposse/terraform-provider-utils/issues/536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module dependency to version 2.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->